### PR TITLE
CLI options

### DIFF
--- a/birdears/__main__.py
+++ b/birdears/__main__.py
@@ -56,8 +56,15 @@ valid_modes = ", ".join(VALID_MODES)
 valid_prequestion_methods = ", ".join(VALID_PREQUESTION_METHODS)
 valid_resolution_methods = ", ".join(VALID_RESOLUTION_METHODS)
 
+# On the help screen, sort commands by definition order, not alphabetically.
+# See https://github.com/pallets/click/issues/513#issuecomment-504158316
+class SortCommands(click.Group):
+    def list_commands(self, ctx):
+        return self.commands.keys()
 
-@click.group(options_metavar='', subcommand_metavar='<command> [options]',
+@click.group(cls=SortCommands,
+             options_metavar='[options]',
+             subcommand_metavar='<command> [--help]',
              epilog=main_epilog,
              context_settings=CTX_SETTINGS)
 @click.option('--debug/--no-debug',

--- a/birdears/__main__.py
+++ b/birdears/__main__.py
@@ -38,7 +38,8 @@ def load_interface(*args, **kwargs):
         from .interfaces.urwid import TextUserInterface
         tui = TextUserInterface(**kwargs)
     else:
-        cli = CommandLine(*args, **kwargs)
+        cli = CommandLine(cli_prompt_next, cli_no_scroll, cli_no_resolution,
+              *args, **kwargs)
 
 
 main_epilog = """
@@ -68,7 +69,16 @@ valid_resolution_methods = ", ".join(VALID_RESOLUTION_METHODS)
 @click.option('--cli/--no-cli',
               help='Uses command line as interface.',
               default=False, envvar='CLI')
-def cli(debug, urwid, cli):
+@click.option('--prompt',
+              help='Wait for input before new question (\'cli\' only)',
+              default=False, is_flag=True, envvar='PROMPT')
+@click.option('--no-scroll',
+              help='Clear screen on new question (implies --prompt)',
+              default=False, is_flag=True, envvar='NO_SCROLL')
+@click.option('--no-resolution',
+              help='Do not play resolution after answer (\'cli\' only)',
+              default=False, is_flag=True, envvar='NO_RESOLUTION')
+def cli(debug, urwid, cli, prompt, no_scroll, no_resolution):
     """birdears ─ Functional Ear Training for Musicians!"""
 
     global INTERFACE
@@ -84,8 +94,17 @@ def cli(debug, urwid, cli):
 
     if cli:
         INTERFACE = 'commandline'
-    elif urwid:
-        INTERFACE = 'urwid'
+    
+        global cli_prompt_next
+        global cli_no_scroll
+        global cli_no_resolution
+        
+        cli_prompt_next = prompt
+        cli_no_scroll = no_scroll
+        cli_no_resolution = no_resolution
+
+        if cli_no_scroll:
+            cli_prompt_next = True
     else:
         INTERFACE = 'urwid'
 

--- a/birdears/__main__.py
+++ b/birdears/__main__.py
@@ -45,7 +45,9 @@ def load_interface(*args, **kwargs):
 main_epilog = """
 You can use 'birdears <command> --help' to show options for a specific command.
 
-More info at https://github.com/iacchus/birdears
+Global options can also be set as environment variables (e.g., DEBUG=1).
+
+More info at https://github.com/iacchus/birdears.
 """
 
 tonics = list(set(CHROMATIC_SHARP + CHROMATIC_FLAT))
@@ -68,13 +70,13 @@ class SortCommands(click.Group):
              epilog=main_epilog,
              context_settings=CTX_SETTINGS)
 @click.option('--debug/--no-debug',
-              help='Turns on debugging; instead you can set DEBUG=1.',
+              help='Turn on debugging',
               default=False, envvar='DEBUG')
 @click.option('--urwid/--no-urwid',
-              help='Uses urwid as interface.',
+              help='Use urwid as interface (default)',
               default=True, envvar='URWID')
 @click.option('--cli/--no-cli',
-              help='Uses command line as interface.',
+              help='Use command line as interface',
               default=False, envvar='CLI')
 @click.option('--prompt',
               help='Wait for input before new question (\'cli\' only)',
@@ -119,7 +121,6 @@ def cli(debug, urwid, cli, prompt, no_scroll, no_resolution):
 # melodic interval
 #
 
-
 melodic_epilog = """
 In this exercise birdears will play two notes, the tonic and the interval
 melodically, ie., one after the other and you should reply which is the correct
@@ -140,7 +141,6 @@ Valid values are as follows:
     valid_resolution_methods=valid_resolution_methods,
     valid_prequestion_methods=valid_prequestion_methods,
 )
-
 
 @cli.command(options_metavar='[options]', epilog=melodic_epilog)
 @click.option('-m', '--mode', type=click.Choice(VALID_MODES),
@@ -176,11 +176,9 @@ def melodic(*args, **kwargs):
     kwargs.update({'exercise': 'melodic'})
     load_interface(*args, **kwargs)
 
-
 #
 # harmonic interval
 #
-
 
 harmonic_epilog = """
 In this exercise birdears will play two notes, the tonic and the interval
@@ -202,7 +200,6 @@ Valid values are as follows:
     valid_resolution_methods=valid_resolution_methods,
     valid_prequestion_methods=valid_prequestion_methods,
 )
-
 
 @cli.command(options_metavar='[options]', epilog=harmonic_epilog)
 @click.option('-m', '--mode', metavar='<mode>', type=click.Choice(VALID_MODES),
@@ -239,9 +236,8 @@ def harmonic(*args, **kwargs):
     load_interface(*args, **kwargs)
 
 #
-# dictation
+# melodic dictation
 #
-
 
 dictation_epilog = """
 In this exercise birdears will choose some random intervals and create a
@@ -264,7 +260,6 @@ Valid values are as follows:
     valid_resolution_methods=valid_resolution_methods,
     valid_prequestion_methods=valid_prequestion_methods,
 )
-
 
 @cli.command(options_metavar='[options]', epilog=dictation_epilog)
 @click.option('-m', '--mode', metavar='<mode>', type=click.Choice(VALID_MODES),
@@ -306,14 +301,13 @@ def dictation(*args, **kwargs):
     kwargs.update({'exercise': 'dictation'})
     load_interface(*args, **kwargs)
 
-
 #
 # instrumental dictation
 #
 
 instrumental_epilog = """
 In this exercise birdears will choose some random intervals and create a
-melodic dictation with them. You should play the correct melody in you musical
+melodic dictation with them. You should play the correct melody on your musical
 instrument.
 
 Valid values are as follows:
@@ -331,7 +325,6 @@ Valid values are as follows:
     valid_resolution_methods=valid_resolution_methods,
     valid_prequestion_methods=valid_prequestion_methods,
 )
-
 
 @cli.command(options_metavar='[options]', epilog=instrumental_epilog)
 @click.option('-m', '--mode', metavar='<mode>', type=click.Choice(VALID_MODES),
@@ -371,12 +364,15 @@ Valid values are as follows:
               metavar='<resolution_method>',
               help='The name of a resolution method.')
 def instrumental(*args, **kwargs):
-    """Instrumental melodic time-based dictation
+    """Instrumental melodic dictation (time-based)
     """
 
     kwargs.update({'exercise': 'instrumental'})
     load_interface(*args, **kwargs)
 
+#
+# notename
+#
 
 notename_epilog = """
 In this exercise birdears will play two notes, the tonic and the interval
@@ -398,7 +394,6 @@ Valid values are as follows:
     valid_resolution_methods=valid_resolution_methods,
     valid_prequestion_methods=valid_prequestion_methods,
 )
-
 
 @cli.command(options_metavar='[options]', epilog=notename_epilog)
 @click.option('-m', '--mode', type=click.Choice(VALID_MODES),
@@ -428,27 +423,20 @@ Valid values are as follows:
               metavar='<resolution_method>',
               help='The name of a resolution method.')
 def notename(*args, **kwargs):
-    """Note name by intervaç recognition
+    """Note name by interval recognition
     """
 
     kwargs.update({'exercise': 'notename'})
     load_interface(*args, **kwargs)
 
-
 #
-# birdear's "load"
+# load preset config
 #
 
-
-load_epilog = """
-Loads exercise from file.
-"""
-
-
-@cli.command(options_metavar='', epilog=load_epilog)
+@cli.command(options_metavar='')
 @click.argument('filename', type=click.File(), metavar='<filename>')
 def load(filename, *args, **kwargs):
-    """Loads exercise from .toml config file <filename>.
+    """Load exercise preset from .toml config file <filename>.
     """
 
     from .toml import toml

--- a/birdears/__main__.py
+++ b/birdears/__main__.py
@@ -65,7 +65,7 @@ valid_resolution_methods = ", ".join(VALID_RESOLUTION_METHODS)
               default=False, envvar='DEBUG')
 @click.option('--urwid/--no-urwid',
               help='Uses urwid as interface.',
-              default=False, envvar='URWID')
+              default=True, envvar='URWID')
 @click.option('--cli/--no-cli',
               help='Uses command line as interface.',
               default=False, envvar='CLI')
@@ -92,7 +92,7 @@ def cli(debug, urwid, cli, prompt, no_scroll, no_resolution):
         logger.setLevel(logging.DEBUG)
         logger.debug('debug is on.')
 
-    if cli:
+    if cli or not urwid:
         INTERFACE = 'commandline'
     
         global cli_prompt_next

--- a/birdears/interfaces/commandline.py
+++ b/birdears/interfaces/commandline.py
@@ -176,10 +176,15 @@ def make_input_str(user_input, keyboard_index):
 
 class CommandLine:
 
-    def __init__(self, exercise=None, *args, **kwargs):
+    def __init__(self, cli_prompt_next=False,
+                 cli_no_scroll=False, cli_no_resolution=False,
+                 exercise=None, *args, **kwargs):
         """This function implements the birdears loop for command line.
 
         Args:
+            cli_prompt_next (bool): True if --prompt is set.
+            cli_no_scroll (bool): True if --no-scroll is set.
+            cli_no_resolution (bool): True if --no-resolution is set.
             exercise (str): The question name.
             **kwargs (kwargs): FIXME: The kwargs can contain options for
                 specific questions.
@@ -190,6 +195,10 @@ class CommandLine:
         else:
             raise Exception("Invalid `exercise` value:", exercise)
         
+        self.prompt_next = cli_prompt_next
+        self.no_scroll = cli_no_scroll
+        self.no_resolution = cli_no_resolution
+
         self.exercise = exercise
 
         ####if 'n_notes' in kwargs:
@@ -200,6 +209,8 @@ class CommandLine:
         getch = _Getch()
 
         self.new_question_bit = True
+
+        print('\n')
 
         while True:
             if self.new_question_bit is True:
@@ -234,11 +245,12 @@ class CommandLine:
                                       'second note.' \
                                       .format(tonic=self.question.tonic_str)
 
-                # Clear terminal screen (but keep scrollback)
-                # See https://stackoverflow.com/a/2084628
-                os.system('cls' if os.name == 'nt' else 'clear -x')
+                if self.no_scroll:
+                    # Clear terminal screen (but keep scrollback)
+                    # See https://stackoverflow.com/a/2084628
+                    os.system('cls' if os.name == 'nt' else 'clear -x')
+                    print('\n')
 
-                print('\n')
                 print(center_text(exercise_title, nl=0))
 
                 print_question(self.question)
@@ -294,25 +306,27 @@ class CommandLine:
                 response = self.question.check_question(self.input_keys)
                 print_response(response)
 
-                self.question.play_resolution()
+                if not self.no_resolution:
+                    self.question.play_resolution()
                 
-                print(center_text('Next question', nl=0))
-                print(center_text('space- play   q- quit', sep=False, nl=0))
-                
-                getch2 = _Getch()
+                if self.prompt_next:
+                    print(center_text('Next question', nl=0))
+                    print(center_text('space- play   q- quit', sep=False, nl=1))
+                    
+                    getch2 = _Getch()
 
-                while True: # wait for input before next question
-                    user_input2 = getch2()
-                
-                    # spacebar, enter - play next question
-                    if user_input2 in (' ', '\r'):
-                        break
-                    # q - quit
-                    elif user_input2 in ('q', 'Q'):
-                        exit(0)
-                    # loop, keep waiting
-                    else:
-                        pass
+                    while True: # wait for input before next question
+                        user_input2 = getch2()
+                    
+                        # spacebar, enter - play next question
+                        if user_input2 in (' ', '\r'):
+                            break
+                        # q - quit
+                        elif user_input2 in ('q', 'Q'):
+                            exit(0)
+                        # loop, keep waiting
+                        else:
+                            pass
 
                 self.new_question_bit = True
 


### PR DESCRIPTION
This PR adds 3 options for the CLI interface and updates the main help page.

With the `melodic` exercise as an example, the new CLI options are:
+ `birdears --cli melodic`: restore default behavior (same as TUI)
+ `birdears --cli --no-resolution melodic`: do not play resolution
  + for speedruns with settings like `--user_durations '1.5,n,0.25, 1.5,n,0.25, n,n,n'`
+ `birdears --cli --prompt melodic`: wait for input before new question
+ `birdears --cli --no-scroll melodic`: wait for input , then clear screen on new question

On the help page:
+ fix usage:
  + from `birdears <command> [options]`
  + to `birdears [options] <command> [--help]`
  + global options must be placed *before* subcommands
+ add new options
+ reorder commands from *alphabetic* to *definition* order:
  + now *melodic, harmonic, dictation, instrumental, notename,* then *load*

Also, fix `--no-urwid` which had no effect. Now works like `--cli`.