### PR TITLE
fix "Warning: invalid `valid_interval`: (0" with default CHROMATIC_TYPE

### DIFF
--- a/src/birdears/__init__.py
+++ b/src/birdears/__init__.py
@@ -80,9 +80,9 @@ INTERVALS = (
 A tuple of tuples representing data for the intervals with format
 (semitones, short name, full name)."""
 
-CHROMATIC_TYPE = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
-# CHROMATIC_TYPE = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-"""tuple: A map of the chromatic scale.
+CHROMATIC_TYPE = '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11'
+# CHROMATIC_TYPE = '0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12'
+"""str: A map of the chromatic scale.
 
 A map of the the semitones which compound the chromatic scale."""
 

--- a/src/birdears/questionbase.py
+++ b/src/birdears/questionbase.py
@@ -53,7 +53,7 @@ def get_valid_pitches(scale, valid_intervals=CHROMATIC_TYPE):
     elif isinstance(valid_intervals, str):
         valid_list = valid_intervals.replace(' ', '').split(',')
     else:
-        raise Exception('Incorrect type for valid_semitones')
+        raise Exception('Incorrect type for valid_intervals')
 
     valid_semitones = list()
 
@@ -67,7 +67,7 @@ def get_valid_pitches(scale, valid_intervals=CHROMATIC_TYPE):
             valid_semitones.append(int(item))
         # something else
         else:
-            print('Warning: invalid `valid_interval`: ', item)
+            print('Warning: incorrect item in `valid_list`: ', item)
             continue
 
     for pitch in scale:


### PR DESCRIPTION
With latest commits after the pyscaffold merge,

I get ```Warning: invalid `valid_interval`:  (0``` and ```Warning: invalid `valid_interval`:  11)``` when running birdears without a `--valid_intervals` option (e.g., with `birdears --cli melodic`).

Looks like `click` 8.0 is causing the issue. It converts the default CHROMATIC_TYPE tuple to a string.
If I comment the following lines, CHROMATIC_TYPE remains a tuple:

https://github.com/iacchus/birdears/blob/07af23b91925397bb286235e18c342437a5532d8/src/birdears/__main__.py#L165-L167

The effect can be seen by adding `print(type(valid_intervals))` somewhere at the beginning of the `get_valid_pitches()` function (shown below), then running birdears:

https://github.com/iacchus/birdears/blob/07af23b91925397bb286235e18c342437a5532d8/src/birdears/questionbase.py#L42-L44

I tried a few things to fix this. By far the easiest solution is to set CHROMATIC_TYPE as a string in the first place.
It is what this PR does.

P.S.: Thanks for removing click, toml and urwid packages from the project and adding as dependencies instead. Tidier this way!