### PR TITLE
Refactor CommandLine interface

### DIFF
--- a/src/birdears/__main__.py
+++ b/src/birdears/__main__.py
@@ -39,6 +39,7 @@ def load_interface(*args, **kwargs):
     else:
         cli = CommandLine(cli_prompt_next, cli_no_scroll, cli_no_resolution,
               *args, **kwargs)
+        cli.run()
 
 
 main_epilog = """

--- a/src/birdears/interfaces/commandline.py
+++ b/src/birdears/interfaces/commandline.py
@@ -27,158 +27,6 @@ from shutil import get_terminal_size
 COLS, LINES = get_terminal_size()
 
 
-def center_text(text, sep=True, nl=0):
-    """This function returns input text centered according to terminal columns.
-
-    Args:
-        text (str): The string to be centered, it can have multiple lines.
-        sep (bool): Add line separator after centered text (True) or
-            not (False).
-        nl (int): How many new lines to add after text.
-    """
-
-    linelist = list(text.splitlines())
-
-    # gets the biggest line
-    biggest_line_size = 0
-    for line in linelist:
-        line_length = len(line.expandtabs())
-        if line_length > biggest_line_size:
-            biggest_line_size = line_length
-
-    columns = COLS
-    offset = biggest_line_size / 2
-    perfect_center = columns / 2
-    padsize = int(perfect_center - offset)
-    spacing = ' ' * padsize  # space char
-    dim = '\033[2m'
-    reset = '\033[0m'
-
-    text = str()
-    for line in linelist:
-        text += (spacing + line + '\n')
-
-    divider = \
-        spacing + (dim + '─' * int(biggest_line_size) + reset) # unicode 0x2500
-
-    text += divider if sep else ''
-
-    text += nl * '\n'
-
-    return text
-
-
-def print_response(response):
-    """Prints the formatted response.
-
-    Args:
-        response (dict): A response returned by question's check_question()
-    """
-
-    # TODO: make a class for response
-    if response['is_correct']:
-        response_text = "Correct!"
-        color = '\033[32m' # green
-    else:
-        response_text = "Wrong"
-        color = '\033[31m' # red
-
-    reset = '\033[0m' # reset terminal color
-
-    if 'extra_response_str' in response.keys():
-        print(center_text(response['extra_response_str'], nl=0))
-
-    print(color + center_text(response_text, sep=False, nl=1) + reset)
-
-
-def print_instrumental(response):
-    """Prints the formatted response for 'instrumental' exercise.
-
-    Args:
-        response (dict): A response returned by question's check_question()
-    """
-
-    text_kwargs = dict(
-        correct_resp=response['correct_response_str']
-    )
-
-    response_text = """
-{correct_resp}
-""".format(**text_kwargs)
-
-    print(center_text(response_text, nl=2))
-
-
-def print_question(question):
-    """Prints the question to the user.
-
-    Args:
-        question (obj): A Question class with the question to be printed.
-    """
-
-    direction = -1 if question.is_descending else +1
-
-    scale = question.scale
-    # mode = question.mode
-
-    tonic = scale[0]
-    network = [abs(int(tonic) - int(note)) for note in scale]
-    # keyboard_map = KEYBOARD_INDICES['chromatic']['ascending']['major']
-    keyboard_map = tuple(question.keyboard_index)
-
-    # should we show the octaves here? why not?
-
-    notes = "".join([str(pitch).ljust(4) for pitch in scale][::direction])
-    # notes = "".join([str(pitch.note).ljust(4) \
-    # for pitch in scale][::direction])
-    intervals = "".join([str(INTERVALS[step][1]).ljust(4)
-                         for step in network][::direction])
-    keys = "".join([str(keyboard_map[step]).ljust(4)
-                    for step in network][::direction])
-
-    text_kwargs = {
-        'tonic': question.tonic_str,
-        'mode': question.mode,
-        'chroma': question.is_chromatic,
-        'desc': question.is_descending,
-        'scale': notes,
-        'intervals': intervals,
-        'keyboard': keys,
-    }
-
-    question_text = """\
-     Scale: {scale}
- Intervals: {intervals}
-  Keyboard: {keyboard}
-""".format(**text_kwargs)
-
-    print(center_text(question_text, nl=2))
-
-
-def make_input_str(user_input, keyboard_index):
-    """Makes a string representing intervals entered by the user.
-
-    This function is to be used by questions which takes more than one interval
-    input as MelodicDictation, and formats the intervals already entered.
-
-    Args:
-        user_input (array_type): The list of keyboard keys entered by user.
-        keyboard_index (array_type): The keyboard mapping used by question.
-    """
-
-    input_str = str()
-
-    user_input_semitones = [keyboard_index.index(s)
-                            for s in user_input]
-
-    user_str = "".join([INTERVALS[s][1].center(5)
-                       for s in user_input_semitones]).center(COLS)
-
-    input_str = ("\r{}".format(user_str))
-
-    return input_str
-
-
 class CommandLine:
 
     def __init__(self, cli_prompt_next=False,
@@ -196,25 +44,176 @@ class CommandLine:
         """
 
         if exercise in QUESTION_CLASSES:
-            QUESTION_CLASS = QUESTION_CLASSES[exercise]
+            self.QUESTION_CLASS = QUESTION_CLASSES[exercise]
         else:
             raise Exception("Invalid `exercise` value:", exercise)
-        
+
         self.prompt_next = cli_prompt_next
         self.no_scroll = cli_no_scroll
         self.no_resolution = cli_no_resolution
 
         self.exercise = exercise
+        self.kwargs = kwargs
 
         ####if 'n_notes' in kwargs:
             ####self.dictate_notes = kwargs['n_notes']
         ####else:
             ####self.dictate_notes = 1
 
-        getch = _Getch()
+        self.getch = _Getch()
 
         self.new_question_bit = True
+        self.input_keys = list()
+        self.question = None
 
+    def center_text(self, text, sep=True, nl=0):
+        """This function returns input text centered according to terminal columns.
+
+        Args:
+            text (str): The string to be centered, it can have multiple lines.
+            sep (bool): Add line separator after centered text (True) or
+                not (False).
+            nl (int): How many new lines to add after text.
+        """
+
+        linelist = list(text.splitlines())
+
+        # gets the biggest line
+        biggest_line_size = 0
+        for line in linelist:
+            line_length = len(line.expandtabs())
+            if line_length > biggest_line_size:
+                biggest_line_size = line_length
+
+        columns = COLS
+        offset = biggest_line_size / 2
+        perfect_center = columns / 2
+        padsize = int(perfect_center - offset)
+        spacing = ' ' * padsize  # space char
+        dim = '\033[2m'
+        reset = '\033[0m'
+
+        text = str()
+        for line in linelist:
+            text += (spacing + line + '\n')
+
+        divider = \
+            spacing + (dim + '─' * int(biggest_line_size) + reset) # unicode 0x2500
+
+        text += divider if sep else ''
+
+        text += nl * '\n'
+
+        return text
+
+    def print_response(self, response):
+        """Prints the formatted response.
+
+        Args:
+            response (dict): A response returned by question's check_question()
+        """
+
+        # TODO: make a class for response
+        if response['is_correct']:
+            response_text = "Correct!"
+            color = '\033[32m' # green
+        else:
+            response_text = "Wrong"
+            color = '\033[31m' # red
+
+        reset = '\033[0m' # reset terminal color
+
+        if 'extra_response_str' in response.keys():
+            print(self.center_text(response['extra_response_str'], nl=0))
+
+        print(color + self.center_text(response_text, sep=False, nl=1) + reset)
+
+    def print_instrumental(self, response):
+        """Prints the formatted response for 'instrumental' exercise.
+
+        Args:
+            response (dict): A response returned by question's check_question()
+        """
+
+        text_kwargs = dict(
+            correct_resp=response['correct_response_str']
+        )
+
+        response_text = """
+{correct_resp}
+""".format(**text_kwargs)
+
+        print(self.center_text(response_text, nl=2))
+
+    def print_question(self, question):
+        """Prints the question to the user.
+
+        Args:
+            question (obj): A Question class with the question to be printed.
+        """
+
+        direction = -1 if question.is_descending else +1
+
+        scale = question.scale
+        # mode = question.mode
+
+        tonic = scale[0]
+        network = [abs(int(tonic) - int(note)) for note in scale]
+        # keyboard_map = KEYBOARD_INDICES['chromatic']['ascending']['major']
+        keyboard_map = tuple(question.keyboard_index)
+
+        # should we show the octaves here? why not?
+
+        notes = "".join([str(pitch).ljust(4) for pitch in scale][::direction])
+        # notes = "".join([str(pitch.note).ljust(4) \
+        # for pitch in scale][::direction])
+        intervals = "".join([str(INTERVALS[step][1]).ljust(4)
+                             for step in network][::direction])
+        keys = "".join([str(keyboard_map[step]).ljust(4)
+                        for step in network][::direction])
+
+        text_kwargs = {
+            'tonic': question.tonic_str,
+            'mode': question.mode,
+            'chroma': question.is_chromatic,
+            'desc': question.is_descending,
+            'scale': notes,
+            'intervals': intervals,
+            'keyboard': keys,
+        }
+
+        question_text = """\
+     Scale: {scale}
+ Intervals: {intervals}
+  Keyboard: {keyboard}
+""".format(**text_kwargs)
+
+        print(self.center_text(question_text, nl=2))
+
+    def make_input_str(self, user_input, keyboard_index):
+        """Makes a string representing intervals entered by the user.
+
+        This function is to be used by questions which takes more than one interval
+        input as MelodicDictation, and formats the intervals already entered.
+
+        Args:
+            user_input (array_type): The list of keyboard keys entered by user.
+            keyboard_index (array_type): The keyboard mapping used by question.
+        """
+
+        input_str = str()
+
+        user_input_semitones = [keyboard_index.index(s)
+                                for s in user_input]
+
+        user_str = "".join([INTERVALS[s][1].center(5)
+                           for s in user_input_semitones]).center(COLS)
+
+        input_str = ("\r{}".format(user_str))
+
+        return input_str
+
+    def run(self):
         print('\n')
 
         while True:
@@ -223,7 +222,7 @@ class CommandLine:
                 self.new_question_bit = False
 
                 self.input_keys = list()
-                self.question = QUESTION_CLASS(**kwargs)
+                self.question = self.QUESTION_CLASS(**self.kwargs)
 
                 if   self.exercise == 'melodic':
                     exercise_title  = 'Melodic interval recognition'
@@ -256,19 +255,19 @@ class CommandLine:
                     os.system('cls' if os.name == 'nt' else 'clear -x')
                     print('\n')
 
-                print(center_text('birdears ─ Functional Ear Training',
+                print(self.center_text('birdears ─ Functional Ear Training',
                                   sep=False, nl=1))
-                print(center_text(exercise_title, nl=0))
-                print(center_text('KEY: ' + self.question.tonic_str + ' ' \
+                print(self.center_text(exercise_title, nl=0))
+                print(self.center_text('KEY: ' + self.question.tonic_str + ' ' \
                                   + self.question.mode, sep=False, nl=1))
 
-                print_question(self.question)
+                self.print_question(self.question)
 
                 if not self.exercise == 'instrumental':
                     self.question.play_question()
 
-                    print(center_text(question_prompt))
-                    print(center_text(
+                    print(self.center_text(question_prompt))
+                    print(self.center_text(
                         'key- answer   r- repeat   q- quit', sep=False, nl=1))
 
             if self.exercise == 'instrumental':
@@ -279,17 +278,17 @@ class CommandLine:
                 for i in range(self.question.wait_time):
                     time_left = str(self.question.wait_time - i).rjust(3)
                     text = '{} seconds remaining...'.format(time_left)
-                    print(center_text(text, sep=False), end='')
+                    print(self.center_text(text, sep=False), end='')
                     self.question.question._wait(1)
 
                 response = self.question.check_question()
-                print_instrumental(response)
+                self.print_instrumental(response)
 
                 self.new_question_bit = True
 
                 continue
 
-            user_input = getch()
+            user_input = self.getch()
             self.process_key(user_input)
 
     def process_key(self, user_input):
@@ -304,7 +303,7 @@ class CommandLine:
                 ###    self.question.keyboard_index)
                 ###print(input_str, end='')
             if self.question.n_input_notes > 1:
-                input_str = make_input_str(self.input_keys,
+                input_str = self.make_input_str(self.input_keys,
                                            self.question.keyboard_index)
                 print(input_str, end='')
 
@@ -313,14 +312,14 @@ class CommandLine:
             if len(self.input_keys) == self.question.n_notes:
 
                 response = self.question.check_question(self.input_keys)
-                print_response(response)
+                self.print_response(response)
 
                 if not self.no_resolution:
                     self.question.play_resolution()
                 
                 if self.prompt_next:
-                    print(center_text('Next question', nl=0))
-                    print(center_text('any- play   q- quit', sep=False, nl=1))
+                    print(self.center_text('Next question', nl=0))
+                    print(self.center_text('any- play   q- quit', sep=False, nl=1))
                     
                     getch2 = _Getch()
 
@@ -345,7 +344,7 @@ class CommandLine:
             #if(len(self.input_keys) > 0) and self.exercise == 'dictation':
             if(len(self.input_keys) > 0) and (self.question.n_input_notes > 1):
                 del(self.input_keys[-1])
-                input_str = make_input_str(self.input_keys,
+                input_str = self.make_input_str(self.input_keys,
                                            self.question.keyboard_index)
                 print(input_str, end='')
 

--- a/src/birdears/questions/instrumentaldictation.py
+++ b/src/birdears/questions/instrumentaldictation.py
@@ -11,8 +11,6 @@ from ..sequence import Sequence
 from ..resolution import Resolution
 from ..prequestion import PreQuestion
 
-from ..interfaces.commandline import center_text
-
 
 @register_question_class
 class InstrumentalDictationQuestion(QuestionBase):

--- a/tests/test_interfaces_commandline.py
+++ b/tests/test_interfaces_commandline.py
@@ -1,4 +1,4 @@
-from birdears.interfaces import commandline
+from birdears.interfaces.commandline import CommandLine
 
 from birdears.questions.melodicinterval import MelodicIntervalQuestion
 from birdears.questions.instrumentaldictation \
@@ -6,57 +6,58 @@ from birdears.questions.instrumentaldictation \
 
 
 def test_centertext():
-    commandline.center_text('test')
+    cli = CommandLine(exercise='melodic')
+    cli.center_text('test')
 
 
 def test_printquestion():
-
+    cli = CommandLine(exercise='melodic')
     a = MelodicIntervalQuestion()
     resp = a.check_question('x')
-    commandline.print_question(a)
+    cli.print_question(a)
     assert(a)
 
     a = MelodicIntervalQuestion(chromatic=True)
     resp = a.check_question('x')
-    commandline.print_question(a)
+    cli.print_question(a)
     assert(a)
 
     a = MelodicIntervalQuestion(descending=True)
     resp = a.check_question('x')
-    commandline.print_question(a)
+    cli.print_question(a)
     assert(a)
 
     a = MelodicIntervalQuestion(n_octaves=2)
     resp = a.check_question('x')
-    commandline.print_question(a)
+    cli.print_question(a)
     assert(a)
 
 
 def test_printresponse():
-
+    cli = CommandLine(exercise='melodic')
     a = MelodicIntervalQuestion()
     resp = a.check_question('x')
-    commandline.print_response(resp)
+    cli.print_response(resp)
     assert(a)
 
     a = MelodicIntervalQuestion(chromatic=True)
     resp = a.check_question('x')
-    commandline.print_response(resp)
+    cli.print_response(resp)
     assert(a)
 
     a = MelodicIntervalQuestion(descending=True)
     resp = a.check_question('x')
-    commandline.print_response(resp)
+    cli.print_response(resp)
     assert(a)
 
     a = MelodicIntervalQuestion(n_octaves=2)
     resp = a.check_question('x')
-    commandline.print_response(resp)
+    cli.print_response(resp)
     assert(a)
 
 
 def test_instrumental_print():
-
+    cli = CommandLine(exercise='melodic')
     a = InstrumentalDictationQuestion()
     resp = a.check_question()
-    commandline.print_instrumental(resp)
+    cli.print_instrumental(resp)


### PR DESCRIPTION
Refactored the `CommandLine` class in `src/birdears/interfaces/commandline.py` to move the main execution loop out of `__init__` and into a `run()` method. Also encapsulated global helper functions (`center_text`, `print_question`, etc.) as methods within the class. This improves testability and code organization.

Updated `src/birdears/__main__.py` to call the new `run()` method.

Updated `tests/test_interfaces_commandline.py` to reflect the changes, ensuring tests instantiate the class and call methods on the instance.

Removed an unused import in `src/birdears/questions/instrumentaldictation.py` that relied on the moved function.

---
*PR created automatically by Jules for task [10231994455383200582](https://jules.google.com/task/10231994455383200582) started by @iacchus*