### PR TITLE
Add progressive ear training presets

### DIFF
--- a/examples/003-CMajor-6th-to-7th.toml
+++ b/examples/003-CMajor-6th-to-7th.toml
@@ -1,0 +1,5 @@
+exercise = 'melodic'
+
+tonic = 'C'
+octave = 4
+valid_intervals = [9, 10, 11]

--- a/examples/004-CMajor-All-Diatonic.toml
+++ b/examples/004-CMajor-All-Diatonic.toml
@@ -1,0 +1,5 @@
+exercise = 'melodic'
+
+tonic = 'C'
+octave = 4
+valid_intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/examples/005-CMajor-Two-Octaves.toml
+++ b/examples/005-CMajor-Two-Octaves.toml
@@ -1,0 +1,6 @@
+exercise = 'melodic'
+
+tonic = 'C'
+octave = 4
+n_octaves = 2
+valid_intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/examples/006-CChromatic-1st-to-4th.toml
+++ b/examples/006-CChromatic-1st-to-4th.toml
@@ -1,0 +1,6 @@
+exercise = 'melodic'
+
+tonic = 'C'
+octave = 4
+chromatic = true
+valid_intervals = [1, 2, 3, 4]

--- a/examples/007-CChromatic-All.toml
+++ b/examples/007-CChromatic-All.toml
@@ -1,0 +1,6 @@
+exercise = 'melodic'
+
+tonic = 'C'
+octave = 4
+chromatic = true
+valid_intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/examples/008-Random-Major.toml
+++ b/examples/008-Random-Major.toml
@@ -1,0 +1,6 @@
+exercise = 'melodic'
+
+tonic = 'r'
+mode = 'major'
+octave = 4
+valid_intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/examples/009-Random-Minor.toml
+++ b/examples/009-Random-Minor.toml
@@ -1,0 +1,6 @@
+exercise = 'melodic'
+
+tonic = 'r'
+mode = 'minor'
+octave = 4
+valid_intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]


### PR DESCRIPTION
Added 7 new TOML preset files in `examples/` to provide a progressive ear training course.
- `003-CMajor-6th-to-7th.toml`: Focus on high intervals.
- `004-CMajor-All-Diatonic.toml`: Full major scale intervals.
- `005-CMajor-Two-Octaves.toml`: Extended range.
- `006-CChromatic-1st-to-4th.toml`: Introduction to chromaticism.
- `007-CChromatic-All.toml`: Full chromatic scale.
- `008-Random-Major.toml`: Random keys in Major.
- `009-Random-Minor.toml`: Random keys in Minor.

---
*PR created automatically by Jules for task [15753355476733992530](https://jules.google.com/task/15753355476733992530) started by @iacchus*