### PR TITLE
Update METHOD.md with I-IV-V-I cadence and resolution logic

### DIFF
--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -8,20 +8,22 @@ In this method, you learn to hear how each note relates to the **tonic** (the ho
 
 The core exercise typically follows this sequence:
 
-1.  **Establish the Key**: A cadence (e.g., I-IV-V-I) is played to firmly establish the key center in your ear.
+1.  **Establish the Key**: A cadence is played to firmly anchor the key center in your ear. We recommend starting with the **I-IV-V-I** progression. While this specific cadence isn't the only standard, it's a powerful and clear way for beginners to lock into the tonality.
 2.  **Play a Note**: A random note from the scale is played.
 3.  **Identify**: You must identify the note's degree (e.g., "Third", "Fifth", "Major Seventh") or name relative to the key.
 4.  **Resolution**: To reinforce the sound, the note is then resolved to the nearest stable tone (the tonic).
 
 ### Resolution Logic
 
-To help internalize the sound, `birdears` automatically resolves the played note to the tonic. This resolution helps you "feel" the gravity of the note.
+To help internalize the sound, `birdears` automatically resolves the played note to the nearest stable tonic. This resolution helps you "feel" the gravity of each note—its pull towards home.
 
--   **Lower Degrees (Unison to Perfect 4th)**: Notes in this range resolve **down** to the tonic below.
-    -   *Example*: In C Major, an F (Perfect 4th) resolves down to C.
--   **Higher Degrees (Perfect 5th to Major 7th)**: Notes in this range resolve **up** to the octave above.
-    -   *Example*: In C Major, a G (Perfect 5th) resolves up to the high C.
--   **Tritone**: The tritone (Augmented 4th / Diminished 5th) is currently resolved **up** to the octave.
+Here's how the magic happens:
+
+-   **From I to IV (Unison to Perfect 4th)**: These notes feel a gravitational pull **downward** and resolve to the **Tonic (I)**.
+    -   *Think of it as*: Falling back to the ground. An F (IV) naturally settles down to C (I).
+-   **From V to VIII (Perfect 5th to Octave)**: These notes feel a lift **upward** and resolve to the **Octave (VIII)**.
+    -   *Think of it as*: Reaching for the sky. A G (V) yearns to climb up to the high C (VIII).
+-   **The Tritone**: This ambiguous interval (Augmented 4th / Diminished 5th) is currently resolved **up** to the octave, adding a touch of suspense before the release.
 
 By hearing these resolutions repeatedly, you learn to anticipate where a note "wants to go," which is the essence of functional hearing.
 


### PR DESCRIPTION
Updated `docs/METHOD.md` to:
- Recommend the I-IV-V-I cadence as a starting point.
- Explain the resolution logic (I-IV -> I, V-VIII -> VIII).
- Improve the overall tone of the "How It Works" and "Resolution Logic" sections.

---
*PR created automatically by Jules for task [11390546113341381228](https://jules.google.com/task/11390546113341381228) started by @iacchus*