### PR TITLE
Remove TODO for get_terminal_size version check

### DIFF
--- a/src/birdears/interfaces/commandline.py
+++ b/src/birdears/interfaces/commandline.py
@@ -13,16 +13,7 @@ from .. import CHROMATIC_TYPE
 
 from ..questionbase import QUESTION_CLASSES
 
-# from os import popen
-
-# TODO: find which version this function was implemented to set minimum python
-#       version.
 from shutil import get_terminal_size
-
-#  try:
-#      from shutil import get_terminal_size
-#  except ImportError:
-#      from click import get_terminal_size
 
 COLS, LINES = get_terminal_size()
 


### PR DESCRIPTION
Resolved a TODO in `src/birdears/interfaces/commandline.py` regarding the minimum Python version for `shutil.get_terminal_size`. Verified that `shutil.get_terminal_size` was added in Python 3.3, and since the project requires Python 3.6+ (enforced by `setup.cfg` and `click` dependency), the function is safe to use without fallbacks. Removed the TODO comment and the associated commented-out legacy fallback code. Confirmed that tests pass with `tox`.

---
*PR created automatically by Jules for task [1175648087575063020](https://jules.google.com/task/1175648087575063020) started by @iacchus*