### PR TITLE
Refactor get_triad to a standalone function

### DIFF
--- a/src/birdears/scale.py
+++ b/src/birdears/scale.py
@@ -73,36 +73,6 @@ class DiatonicScale(ScaleBase):
 
         self.extend(scale)
 
-    # FIXME: aybe ake this a function
-    def get_triad(self, index=0, degree=None):
-        """Returns an array with notes from a scale's triad.
-
-        Args:
-            index (int): triad index (eg.: 0 for 1st degree triad.)
-            degree (int): Degree of the scale. If provided, overrides the
-                `index` argument. (eg.: `1` for the 1st degree triad.)
-        Returns:
-            An array with three pitches, one for each note of the triad.
-        """
-
-        tonic = self.tonic
-        mode = self.mode
-
-        diatonic = DiatonicScale(tonic=tonic.note, mode=mode,
-                                 octave=tonic.octave, n_octaves=2,
-                                 descending=False, dont_repeat_tonic=False)
-
-        if degree:
-            index = degree - 1
-
-        form = [0, 2, 4]
-
-        triad = [diatonic[index+note] for note in form]
-
-        chord = Chord(triad)
-
-        return chord
-
     def __repr__(self):
 
         repr = "<DiatonicScale {tonic} {mode} {direction} {first}-{to} " \
@@ -160,31 +130,31 @@ class ChromaticScale(ScaleBase):
 
         self.extend(scale)
 
-    def get_triad(self, mode, index=0, degree=None):
-        """Returns an array with notes from a scale's triad.
 
-        Args:
-            mode (str): Mode of the scale (eg. 'major' or 'minor')
-            index (int): Triad index (eg.: 0 for 1st degree triad.)
-            degree (int): Degree of the scale. If provided, overrides the
-                `index` argument. (eg.: `1` for the 1st degree triad.)
-        Returns:
-            A list with three pitches (str), one for each note of the triad.
-        """
+def get_triad(tonic, mode, index=0, degree=None):
+    """Returns an array with notes from a scale's triad.
 
-        tonic = self.tonic
+    Args:
+        tonic (Pitch): The tonic pitch of the scale.
+        mode (str): Mode of the scale (eg. 'major' or 'minor')
+        index (int): Triad index (eg.: 0 for 1st degree triad.)
+        degree (int): Degree of the scale. If provided, overrides the
+            `index` argument. (eg.: `1` for the 1st degree triad.)
+    Returns:
+        An array with three pitches, one for each note of the triad.
+    """
 
-        diatonic = DiatonicScale(tonic=tonic.note, mode=mode,
-                                 octave=tonic.octave, n_octaves=2,
-                                 descending=False, dont_repeat_tonic=False)
+    diatonic = DiatonicScale(tonic=tonic.note, mode=mode,
+                             octave=tonic.octave, n_octaves=2,
+                             descending=False, dont_repeat_tonic=False)
 
-        if degree:
-            index = degree - 1
+    if degree:
+        index = degree - 1
 
-        form = [0, 2, 4]
+    form = [0, 2, 4]
 
-        triad = [diatonic[index+note] for note in form]
+    triad = [diatonic[index+note] for note in form]
 
-        chord = Chord(triad)
+    chord = Chord(triad)
 
-        return chord
+    return chord

--- a/src/birdears/sequence.py
+++ b/src/birdears/sequence.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 
 from .scale import ChromaticScale
+from .scale import get_triad
 
 from .note_and_pitch import Pitch
 from .note_and_pitch import Chord
@@ -129,12 +130,8 @@ class Sequence(list):
                 of each triad.
         """
 
-        tonic_str = tonic_pitch.note
-        octave = tonic_pitch.octave
-        scale = ChromaticScale(tonic=tonic_str, octave=octave)
-
         for degree in degrees:
-            chord = scale.get_triad(mode=mode, degree=degree)
+            chord = get_triad(tonic=tonic_pitch, mode=mode, degree=degree)
             self.append(chord)
 
     @log_event

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,6 +11,7 @@ from birdears.interval import Interval
 from birdears.scale import ScaleBase
 from birdears.scale import DiatonicScale
 from birdears.scale import ChromaticScale
+from birdears.scale import get_triad
 
 from birdears.sequence import Sequence
 
@@ -160,7 +161,7 @@ def test_diatonicscaleclass():
 def test_diatonicscale_gettriad():
 
     a = DiatonicScale(tonic='C', mode='major')
-    b = a.get_triad(degree=7)
+    b = get_triad(tonic=a.tonic, mode=a.mode, degree=7)
     assert(b)
 
 
@@ -173,7 +174,7 @@ def test_chromaticscaleclass():
 def test_chromaticscale_gettriad():
 
     a = ChromaticScale(tonic='C')
-    b = a.get_triad(mode='major', degree=7)
+    b = get_triad(tonic=a.tonic, mode='major', degree=7)
     assert(b)
 
 


### PR DESCRIPTION
Refactored `get_triad` from a method in `DiatonicScale` and `ChromaticScale` to a standalone function in `src/birdears/scale.py`.
Updated `src/birdears/sequence.py` and `tests/test_basic.py` to use the new function.
This change simplifies the codebase and removes code duplication.

---
*PR created automatically by Jules for task [16998189263204757659](https://jules.google.com/task/16998189263204757659) started by @iacchus*