### PR TITLE
Refactor Note equality check to use isinstance

### DIFF
--- a/src/birdears/note_and_pitch.py
+++ b/src/birdears/note_and_pitch.py
@@ -78,15 +78,11 @@ class Note:
         # TODO: think a way to compare pitchs vs strings vs notes
 
         # FIXME: we should use isinstance() here
-        if type(compare) == str and str(self) == compare:
+        if isinstance(compare, str) and str(self) == compare:
             return True
 
-        elif type(compare) == Note and int(self) == int(compare):
+        elif isinstance(compare, Note) and int(self) == int(compare):
             return True
-
-        elif type(compare) == Pitch and int(self) == int(compare):
-            return True
-
 
         return False
 

--- a/tests/test_note_equality.py
+++ b/tests/test_note_equality.py
@@ -1,0 +1,28 @@
+from birdears.note_and_pitch import Note, Pitch
+
+def test_note_equality():
+    n = Note('C')
+    assert n == 'C'
+    assert n != 'D'
+    assert n == Note('C')
+    assert n != Note('D')
+
+    # Pitch equality behavior
+    # n is C (pitch class 0)
+    # p is C4 (pitch number 48)
+    p = Pitch('C', 4)
+    # n == p: Note.__eq__(p) -> isinstance(p, Note) -> int(n)=0 == int(p)=48 -> False.
+    assert n != p
+
+    # p0 is C0 (pitch number 0)
+    p0 = Pitch('C', 0)
+    # n == p0: Note.__eq__(p0) -> isinstance(p0, Note) -> int(n)=0 == int(p0)=0 -> True.
+    assert n == p0
+
+    # Test subclasses of str
+    class MyString(str):
+        pass
+
+    ms = MyString('C')
+    # With isinstance() check, this should be True.
+    assert n == ms


### PR DESCRIPTION
Refactored the `__eq__` method in `src/birdears/note_and_pitch.py` to use `isinstance` instead of `type`. This allows for better support of subclasses (like `Pitch` and potential custom string classes) and simplifies the logic by removing redundant checks. A new test file `tests/test_note_equality.py` was added to verify the changes and ensure no regressions.

---
*PR created automatically by Jules for task [4769170526272498564](https://jules.google.com/task/4769170526272498564) started by @iacchus*