### PR TITLE
Document kwargs in CommandLine class

### DIFF
--- a/src/birdears/interfaces/commandline.py
+++ b/src/birdears/interfaces/commandline.py
@@ -182,8 +182,24 @@ class CommandLine:
             cli_no_scroll (bool): True if --no-scroll is set.
             cli_no_resolution (bool): True if --no-resolution is set.
             exercise (str): The question name.
-            **kwargs (kwargs): FIXME: The kwargs can contain options for
-                specific questions.
+            **kwargs: Keyword arguments passed to the question class.
+                Common arguments include:
+                - mode (str): The mode of the question (e.g., 'major', 'minor').
+                - tonic (str): The tonic of the question (e.g., 'C').
+                - octave (int): A scientific octave notation.
+                - descending (bool): Is the question direction in descending.
+                - chromatic (bool): If the question can have chromatic intervals.
+                - n_octaves (int): Maximum number of octaves of the question.
+                - valid_intervals (list): A list with valid intervals (int).
+                - user_durations (str): A string with default durations.
+                - prequestion_method (str): Method of playing a cadence.
+                - resolution_method (str): Method of playing the resolution.
+
+                Specific question arguments:
+                - n_notes (int): The number of notes (dictation).
+                - max_intervals (int): Max number of random intervals (dictation).
+                - wait_time (float): Wait time in seconds (instrumental).
+                - n_repeats (int): Number of repeats (instrumental).
         """
 
         if exercise in QUESTION_CLASSES:


### PR DESCRIPTION
Document kwargs in CommandLine class

Updated the docstring of the `CommandLine` class in `src/birdears/interfaces/commandline.py` to explicitly list the accepted `kwargs`.
The `kwargs` are passed to the underlying question classes and include common arguments like `mode`, `tonic`, `octave` as well as specific arguments for certain question types like `n_notes` and `wait_time`.
This addresses the FIXME in the code and provides better documentation for developers.

---
*PR created automatically by Jules for task [7545368997493481347](https://jules.google.com/task/7545368997493481347) started by @iacchus*