### PR TITLE
Fix descending keys for diatonic modes

### DIFF
--- a/EXPLANATION.md
+++ b/EXPLANATION.md
@@ -1,0 +1,22 @@
+# Fix Explanation: Descending Keys for Diatonic Modes
+
+The original implementation of descending keys for diatonic modes in `src/birdears/__init__.py` was marked with `# FIXME` and contained strings that were exact copies of the ascending keys. This was incorrect for several reasons:
+
+1.  **Directionality**: A descending scale should start from the highest pitch (key `,` on the mapping) and move to the lowest pitch (`z`). The original strings started with `z` (lowest key), representing an ascending movement.
+2.  **Interval Sequence**:
+    *   **Major Scale (Ascending)**: W-W-H-W-W-W-H (e.g., C-D-E-F-G-A-B-C).
+    *   **Major Scale (Descending)**: The intervals are reversed: H-W-W-W-H-W-W (e.g., C-B-A-G-F-E-D-C).
+    *   **Natural Minor Scale (Ascending)**: W-H-W-W-H-W-W (e.g., A-B-C-D-E-F-G-A).
+    *   **Natural Minor Scale (Descending)**: The intervals are reversed: W-W-H-W-W-H-W (e.g., A-G-F-E-D-C-B-A).
+
+The copied strings in the original code preserved the ascending interval structure (W-W-H... for Major, W-H-W... for Minor), which is incorrect for a descending scale.
+
+**The Fix:**
+I replaced the incorrect strings with sequences that:
+1.  Start from `,` and descend to `z`.
+2.  Reflect the correct descending interval patterns by adjusting the spacing (spaces represent whole steps, adjacent characters represent half steps).
+
+*   **New Major Descending**: `,M N B VC X Zm n b vc x z` (H-W-W-W-H-W-W)
+*   **New Minor Descending**: `, M NB V CX Z m nb v cx z` (W-W-H-W-W-H-W)
+
+A regression test `tests/test_keyboard_indices.py` was added to verify these interval sequences programmatically.

--- a/src/birdears/__init__.py
+++ b/src/birdears/__init__.py
@@ -206,10 +206,9 @@ KEYBOARD_INDICES = {
             'minor': 'z xc v bn m Z XC V BN M,',
             'major': 'z x cv b n mZ X CV B NM,'
         },
-        # FIXME
         'descending': {
-            'minor': 'z xc v bn m Z XC V BN M,',
-            'major': 'z x cv b n mZ X CV B NM,'
+            'minor': ', M NB V CX Z m nb v cx z',
+            'major': ',M N B VC X Zm n b vc x z'
         },
     },
     'chromatic': {

--- a/tests/test_keyboard_indices.py
+++ b/tests/test_keyboard_indices.py
@@ -1,0 +1,101 @@
+
+import pytest
+from birdears import KEYBOARD_INDICES
+
+def parse_intervals(key_string):
+    """Parses a keyboard string into a list of semitone intervals."""
+    intervals = []
+    accum = 0
+    # Skip the first key, start checking intervals from there
+    # But strings start with a key.
+    # We need to iterate from the second character?
+    # No, iterate all chars, track state.
+
+    # We assume valid string starts with a key
+    if not key_string:
+        return []
+
+    # Check first char is not space
+    if key_string[0] == ' ':
+        raise ValueError("String starts with space")
+
+    # Start loop from second char
+    # We need to track if we are 'inside' a key sequence
+
+    last_was_space = False
+
+    # Actually, simplistic parser:
+    # Key -> Key : 1 semitone
+    # Key -> Space -> Key : 2 semitones
+    # Key -> Space -> Space -> Key : 3 semitones (unlikely but possible)
+
+    # We just need to count steps between keys.
+    # We can filter out spaces and count indices? No.
+    # We can iterate and count.
+
+    current_interval = 1
+    # Logic:
+    # When we see a key, we record the interval from the PREVIOUS key.
+    # But we need to handle the first key.
+
+    keys_chars = []
+
+    # Sanitize string to list of tokens?
+    # "z x" -> z, space, x
+
+    # Let's iterate index 1 to len
+
+    extracted_intervals = []
+
+    # Check if first char is key
+    if key_string[0] == ' ':
+        return []
+
+    space_count = 0
+
+    for char in key_string[1:]:
+        if char == ' ':
+            space_count += 1
+        else:
+            # It is a key
+            interval = 1 + space_count
+            extracted_intervals.append(interval)
+            space_count = 0
+
+    return extracted_intervals
+
+def test_descending_diatonic_major():
+    # Major Scale Descending Intervals: H, W, W, W, H, W, W
+    # [1, 2, 2, 2, 1, 2, 2]
+    # We expect 2 octaves.
+    expected_intervals = [1, 2, 2, 2, 1, 2, 2] * 2
+
+    # Get the string from __init__.py (after we fix it, but currently it's wrong)
+    # Wait, if I write the test BEFORE fixing, it will fail.
+    # That is good TDD.
+
+    key_string = KEYBOARD_INDICES['diatonic']['descending']['major']
+
+    # We expect this to fail currently because the string is a copy of ascending
+    # Ascending Major (reversed logic? No, just copied)
+    # Copied Ascending: z x cv b n mZ X CV B NM,
+    # Let's see what intervals this parses to.
+    # z->x (W), x->c (W), c->v (H)...
+    # [2, 2, 1, 2, 2, 2, 1] ...
+    # So it parses to Ascending intervals.
+    # But we want Descending intervals [1, 2, 2, 2, 1, 2, 2]
+
+    intervals = parse_intervals(key_string)
+
+    assert intervals == expected_intervals
+
+def test_descending_diatonic_minor():
+    # Natural Minor Descending Intervals: W, W, H, W, W, H, W
+    # [2, 2, 1, 2, 2, 1, 2]
+    expected_intervals = [2, 2, 1, 2, 2, 1, 2] * 2
+
+    key_string = KEYBOARD_INDICES['diatonic']['descending']['minor']
+
+    intervals = parse_intervals(key_string)
+
+    assert intervals == expected_intervals


### PR DESCRIPTION
Fixed incorrect descending key mappings for diatonic major and minor modes in `src/birdears/__init__.py`. Added a regression test `tests/test_keyboard_indices.py` to verify the interval sequence of the key strings.

---
*PR created automatically by Jules for task [4054568551835823562](https://jules.google.com/task/4054568551835823562) started by @iacchus*