### PR TITLE
Pass rich context dictionary to Sequence callback

### DIFF
--- a/src/birdears/sequence.py
+++ b/src/birdears/sequence.py
@@ -62,8 +62,6 @@ class Sequence(list):
                 print('Ctrl+C')
                 exit(0)
 
-        # TODO: later we should passa callback and end_callback here so the
-        # thread can talk to user interfaces, cli/tui/gui etc
         SEQUENCE_THREAD = Thread(target=self.async_play,
                                  kwargs={'callback': callback,
                                          'end_callback': end_callback,
@@ -90,8 +88,17 @@ class Sequence(list):
             is_last = (index == len(self) - 1)
 
             if callback:
+                duration = element.duration or self.duration
+                delay = element.delay or self.delay
 
-                cb_thread = Thread(target=callback, args=[element])
+                element_dict = {
+                    'element': element,
+                    'index': index,
+                    'duration': duration,
+                    'delay': delay,
+                    'is_last': is_last,
+                }
+                cb_thread = Thread(target=callback, args=[element_dict])
                 cb_thread.start()
 
             if type(element) == Pitch:
@@ -107,10 +114,6 @@ class Sequence(list):
                 except KeyboardInterrupt:
                     print('Ctrl+C')
                     exit(0)
-
-            # TODO we should later get the element information and pass via a
-            # dict to Sequence._async_play()'s callback so it can inform the
-            # user interfaces on the status of the element current being played
 
         if self.pos_delay:
             self._wait(self.pos_delay)


### PR DESCRIPTION
Implemented the requirement to pass a rich context dictionary to the `Sequence.play` callback. 

Previously, the callback only received the `element` object. Now it receives a dictionary containing:
- `element`: The Pitch or Chord object.
- `index`: The index of the element in the sequence.
- `duration`: The effective duration of the note/chord.
- `delay`: The effective delay after the note/chord.
- `is_last`: A boolean indicating if this is the last element in the sequence.

This change aligns with the TODOs in the codebase and allows for more sophisticated UI updates during playback.
Verified with a reproduction script and existing tests.

---
*PR created automatically by Jules for task [369242677866646973](https://jules.google.com/task/369242677866646973) started by @iacchus*